### PR TITLE
optimize bestnodefunc

### DIFF
--- a/pkg/scheduler/plugins/networktopology/networktopology.go
+++ b/pkg/scheduler/plugins/networktopology/networktopology.go
@@ -106,17 +106,16 @@ func (ntp *networkTopologyPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		for score, nodes := range nodeScores {
 			if score >= networkExtraScore {
-				unsorted := []string{}
-				sorted := []string{}
-
+				selectdNodes := []string{}
 				for _, node := range nodes {
-					unsorted = append(unsorted, node.Name)
+					selectdNodes = append(selectdNodes, node.Name)
 				}
-				copy(sorted, unsorted)
-				sort.Strings(sorted)
-
-				nodeName := sorted[0]
-				index, _ := indexOf(nodeName, unsorted)
+				sort.Strings(selectdNodes)
+				if len(selectdNodes) == 0 {
+					return nil
+				}
+				nodeName := selectdNodes[0]
+				index, _ := indexOf(nodeName, selectdNodes)
 				return nodes[index]
 			}
 		}


### PR DESCRIPTION
1. copy(a,b) func, a should be set capacity, If not, a will not be appended anything.
2. `nodeName := selectdNodes[0]` will out of index
3. `unsorted` and `sorted` looks redundant.

By the way:
I test this plugin, But it didn't have the expected effect. 
I would be very grateful if you could give me some guidance.

cluster:
``` 
NAME                    STATUS   ROLES           AGE     VERSION
volcano-control-plane   Ready    control-plane   4h35m   v1.30.0
volcano-worker          Ready    <none>          4h35m   v1.30.0
volcano-worker2         Ready    <none>          4h35m   v1.30.0
volcano-worker3         Ready    <none>          4h35m   v1.30.0
volcano-worker4         Ready    <none>          4h35m   v1.30.0
volcano-worker5         Ready    <none>          4h35m   v1.30.0
```

network-topo
```
SwitchName=s0 Nodes=volcano-worker[2-3]
SwitchName=s1 Nodes=volcano-worker[4-5]
SwitchName=s4 Switches=s[0-1]
```

vcjob
```yaml
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  name: p0job
spec:
  minAvailable: 2
  schedulerName: volcano
  queue: default
  tasks:
    - replicas: 2
      name: "default-nginx"
      template:
        metadata:
          name: web
        spec:
          containers:
            - image: nginx:1.27-alpine3.19-slim
              imagePullPolicy: Never
              name: nginx
              resources:
                requests:
                  cpu: 6
          restartPolicy: OnFailure
```

result
```
NAME                    READY   STATUS              RESTARTS   AGE   IP           NODE              NOMINATED NODE   READINESS GATES
p0job-default-nginx-0   0/1     ErrImageNeverPull   0          35m   10.244.2.7   volcano-worker2   <none>           <none>
p0job-default-nginx-1   0/1     ErrImageNeverPull   0          35m   10.244.1.9   volcano-worker    <none>           <none>
```

